### PR TITLE
Fixed support for filenames which have spaces in them.

### DIFF
--- a/lib/Touki/FTP/FilesystemFactory.php
+++ b/lib/Touki/FTP/FilesystemFactory.php
@@ -52,6 +52,7 @@ class FilesystemFactory implements FilesystemFactoryInterface
         $filesystem = $this->resolveFile($type);
         $permParts  = str_split(substr($parts[0], 1, 9), 3);
         $hours      = sscanf($parts[7], "%d:%d");
+        $name       = implode(' ', array_slice($parts, 8));
 
         if (null === $hours[1]) {
             $year  = $hours[0];
@@ -63,7 +64,7 @@ class FilesystemFactory implements FilesystemFactoryInterface
         $date = new \DateTime(sprintf("%s-%s-%s %s:%s", $year, $parts[5], $parts[6], $hours[0], $hours[1]));
 
         $filesystem
-            ->setRealpath(sprintf("%s/%s", $prefix, $parts[8]))
+            ->setRealpath(sprintf("%s/%s", $prefix, $name))
             ->setOwnerPermissions($this->permissionsFactory->build($permParts[0]))
             ->setGroupPermissions($this->permissionsFactory->build($permParts[1]))
             ->setGuestPermissions($this->permissionsFactory->build($permParts[2]))

--- a/lib/Touki/FTP/WindowsFilesystemFactory.php
+++ b/lib/Touki/FTP/WindowsFilesystemFactory.php
@@ -19,10 +19,11 @@ class WindowsFilesystemFactory implements FilesystemFactoryInterface
      */
     public function build($input, $prefix = '')
     {
-        $prefix = rtrim($prefix, '/');
-        $parts  = preg_split("/\s+/", $input);
+        $prefix    = rtrim($prefix, '/');
+        $parts     = preg_split("/\s+/", $input);
         $inputdate = sprintf("%s %s", $parts[0], $parts[1]);
-        $date = \DateTime::createFromFormat('m-d-y H:iA', $inputdate);
+        $date      = \DateTime::createFromFormat('m-d-y H:iA', $inputdate);
+        $name      = implode(' ', array_slice($parts, 3));
 
         if ($parts[2] == '<DIR>') {
             $size = 0;
@@ -33,7 +34,7 @@ class WindowsFilesystemFactory implements FilesystemFactoryInterface
         }
 
         $file
-            ->setRealpath(sprintf("%s/%s", $prefix, $parts[3]))
+            ->setRealpath(sprintf("%s/%s", $prefix, $name))
             ->setSize($size)
             ->setMtime($date)
         ;


### PR DESCRIPTION
Currently the classes do not support files which have spaces in the name, this will resolve this issue by fetching any of the last parts and imploding them together with a space.

Hope you're happy to merge this as I need this support.

Cheers :)
