### PR TITLE
BUGFIX: Replacing the '\' with '/' in methods XByName

### DIFF
--- a/lib/Touki/FTP/Manager/FTPFilesystemManager.php
+++ b/lib/Touki/FTP/Manager/FTPFilesystemManager.php
@@ -176,6 +176,10 @@ class FTPFilesystemManager
     {
         $name = '/'.ltrim($name, '/');
         $directory = dirname($name);
+        
+        // On a Windows server dirname will return a '\' in case of a Windows server.
+        // So replacing the backslashes with slashes to avoid bugs.
+        $directory = str_replace('\\', '/', $directory);
 
         if ($inDirectory) {
             $name      = $inDirectory->getRealpath().$name;
@@ -208,6 +212,10 @@ class FTPFilesystemManager
     {
         $name      = '/'.ltrim($name, '/');
         $directory = dirname($name);
+        
+        // On a Windows server dirname will return a '\' in case of a Windows server.
+        // So replacing the backslashes with slashes to avoid bugs.
+        $directory = str_replace('\\', '/', $directory);        
 
         if ($inDirectory) {
             $name      = $inDirectory->getRealpath().$name;
@@ -240,7 +248,11 @@ class FTPFilesystemManager
     {
         $name      = '/'.ltrim($name, '/');
         $directory = dirname($name);
-
+        
+        // On a Windows server dirname will return a '\' in case of a Windows server.
+        // So replacing the backslashes with slashes to avoid bugs.
+        $directory = str_replace('\\', '/', $directory);
+                        
         if ($inDirectory) {
             $name      = $inDirectory->getRealpath().$name;
             $directory = $inDirectory;


### PR DESCRIPTION
Bug fixed: on a Windows server the php function dirname has returned a '\' if using
the root directory in the FTP-Configuration. This caused that the string '/\' was delivered
to ftp_rawlist as directory name. So no FTP-Operatons were possible in the root directory.

```
modified:   lib/Touki/FTP/Manager/FTPFilesystemManager.php
```
