### PR TITLE
Making rawlist working for hidden files too

### DIFF
--- a/lib/Touki/FTP/FTPWrapper.php
+++ b/lib/Touki/FTP/FTPWrapper.php
@@ -292,7 +292,7 @@ class FTPWrapper
      */
     public function rawlist($directory, $recursive = false)
     {
-        return ftp_rawlist($this->connection->getStream(), $directory, $recursive);
+        return ftp_rawlist($this->connection->getStream(), "-al " . $directory, $recursive);
     }
 
     /**


### PR DESCRIPTION
#### Bug description

`rawlist` in FTPWrapper does not show hidden (dotted) files
#### Suggested solution

The `-al` option will make `ftp_rawlist` display all files (including hidden ones). 
_I do not think that the patch I am suggesting is a good solution, but rather a POC to start a discussion_
