### PR TITLE
Update FilesystemFactory.php

### DIFF
--- a/lib/Touki/FTP/FilesystemFactory.php
+++ b/lib/Touki/FTP/FilesystemFactory.php
@@ -61,7 +61,7 @@ class FilesystemFactory implements FilesystemFactoryInterface
             $year = date('Y');
         }
 
-        $date = new \DateTime(sprintf("%s-%s-%s %s:%s", $year, $parts[5], $parts[6], $hours[0], $hours[1]));
+        $date = new \DateTime(sprintf("%s-%s-%s %s:%s", $year, $parts[5], str_pad($parts[6], 2, '0', STR_PAD_LEFT), $hours[0], $hours[1]));
 
         $filesystem
             ->setRealpath(sprintf("%s/%s", $prefix, $name))


### PR DESCRIPTION
DateTime was not parsed properly if day had only string length one (ex. 2016-Apr-8 instead of 2016-Apr-08)