### PR TITLE
Numbers with a leading zero

### DIFF
--- a/lib/Touki/FTP/FilesystemFactory.php
+++ b/lib/Touki/FTP/FilesystemFactory.php
@@ -61,7 +61,7 @@ class FilesystemFactory implements FilesystemFactoryInterface
             $year = date('Y');
         }
 
-        $date = new \DateTime(sprintf("%s-%s-%s %s:%s", $year, $parts[5], str_pad($parts[6], 2, '0', STR_PAD_LEFT), $hours[0], $hours[1]));
+        $date = new \DateTime(sprintf("%d-%s-%02d %02d:%02d", $year, $parts[5], str_pad($parts[6], 2, '0', STR_PAD_LEFT), $hours[0], $hours[1]));
 
         $filesystem
             ->setRealpath(sprintf("%s/%s", $prefix, $name))


### PR DESCRIPTION
Year, month, day, hours and minutes are a numbers. And day of the month, hours and minutes must be specified with a leading zero, or DateTime incorrectly parses